### PR TITLE
Support for arm64

### DIFF
--- a/AutomergeRSBackend.xcframework/Info.plist
+++ b/AutomergeRSBackend.xcframework/Info.plist
@@ -46,6 +46,7 @@
 			<key>SupportedArchitectures</key>
 			<array>
 				<string>x86_64</string>
+				<string>arm64</string>
 			</array>
 			<key>SupportedPlatform</key>
 			<string>macos</string>


### PR DESCRIPTION
Uses lipo to bring together arm64 & x86_64 into a single binary. The resulting binary looks quite big...