### PR TITLE
[-] remove default public initializer for Actor w/ string

### DIFF
--- a/Source/DataTypes/Actor.swift
+++ b/Source/DataTypes/Actor.swift
@@ -10,6 +10,7 @@ import Foundation
 public struct Actor: Equatable, Hashable, Codable {
 
     public init(actorId: String = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()) {
+        precondition(actorId.allSatisfy { $0.isHexDigit }, "An actorId must be represented with only hexadecimal characters.")
         self.actorId = actorId
     }
 
@@ -45,6 +46,7 @@ extension Actor: CustomStringConvertible {
 extension Actor: ExpressibleByStringLiteral {
 
     public init(stringLiteral value: StringLiteralType) {
+        precondition(value.allSatisfy { $0.isHexDigit }, "An actorId must be represented with only hexadecimal characters.")
         self.init(actorId: value)
     }
 }


### PR DESCRIPTION
Resolves #45

Adding constraint on Actor initialized with a string to match RSBackend conditions: that any strings be represented in hexadecimal characters ONLY. Set up with `precondition`, as we want to consider this a programming error if you've tried to initialize with another string representation.

Note: this only passes all unit tests when merged _after_ #49 

