### PR TITLE
#4 Add += and -= operators on Counter API

### DIFF
--- a/Source/Proxy/Proxy+Counter.swift
+++ b/Source/Proxy/Proxy+Counter.swift
@@ -20,8 +20,59 @@ public extension Proxy where Wrapped == Counter {
     /// Decrements the counter by the value you provide.
     /// - Parameter delta: The amount to decrement the counter, defaults to `1`.
     func decrement(_ delta: Int = -1) {
-       increment(delta)
+        increment(delta)
     }
+    
+    /// Subtracts the second value from the counter by performing a `decrement`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A Counter
+    ///   - rhs: The value to subtract from `lhs`.
+    static func -=(lhs: Proxy, rhs: Int) {
+        lhs.decrement(-rhs)
+    }
+    
+    /// Adds the second value to the counter by performing an `increment`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A Counter
+    ///   - rhs: The value to add to `lhs`.
+    static func +=(lhs: Proxy, rhs: Int) {
+        lhs.increment(rhs)
+    }
+}
 
+public extension Proxy where Wrapped == Optional<Counter> {
+    /// Increments the counter by the value you provide.
+    /// - Parameter delta: The amount to increment the counter, defaults to `1`.
+    func increment(_ delta: Int = 1) {
+        var path = self.path
+        let pathComponent = path.popLast()
+        context.increment(path: path, key: pathComponent!.key, delta: delta)
+    }
+    
+    /// Decrements the counter by the value you provide.
+    /// - Parameter delta: The amount to decrement the counter, defaults to `1`.
+    func decrement(_ delta: Int = -1) {
+        increment(delta)
+    }
+    
+    /// Subtracts the second value from the counter by performing a `decrement`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A Counter
+    ///   - rhs: The value to subtract from `lhs`.
+    static func -=(lhs: Proxy, rhs: Int) {
+        lhs.decrement(-rhs)
+    }
+    
+    /// Adds the second value to the counter by performing an `increment`.
+    ///
+    /// - Parameters:
+    ///   - lhs: A Counter
+    ///   - rhs: The value to add to `lhs`.
+    static func +=(lhs: Proxy, rhs: Int) {
+        lhs.increment(rhs)
+    }
 }
 

--- a/Tests/Proxy+CounterTests.swift
+++ b/Tests/Proxy+CounterTests.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  
+//
+//  Created by Konstantin Kostov on 23/06/2022.
+//
+
+import Foundation
+import XCTest
+@testable import Automerge
+
+class ProxyCounterTests: XCTestCase {
+    func testAssignmentExpressions() {
+        struct Schema: Codable, Equatable {
+            var counter: Counter?
+            var notOptionalCounter: Counter = 3
+        }
+        
+        var doc1 = Document(Schema())
+        let _ = doc1.change {
+            $0.counter?.set(3)
+            XCTAssertEqual($0.counter?.get(), 3)
+        }
+        
+        let _ = doc1.change {
+            $0.counter -= 1
+            $0.notOptionalCounter -= 1
+            XCTAssertEqual($0.counter?.get(), 2)
+            XCTAssertEqual($0.notOptionalCounter.get(), 2)
+        }
+        
+        let _ = doc1.change {
+            $0.counter += 2
+            $0.notOptionalCounter += 2
+            XCTAssertEqual($0.counter?.get(), 4)
+            XCTAssertEqual($0.notOptionalCounter.get(), 4)
+        }
+        
+        let _ = doc1.change {
+            $0.counter += -2
+            $0.notOptionalCounter -= 2
+            XCTAssertEqual($0.counter?.get(), 2)
+            XCTAssertEqual($0.notOptionalCounter.get(), 2)
+        }
+        
+        XCTAssertEqual(doc1.content, Schema(counter: 2, notOptionalCounter: 2))
+    }
+}

--- a/Tests/Proxy+CounterTests.swift
+++ b/Tests/Proxy+CounterTests.swift
@@ -10,10 +10,23 @@ import XCTest
 @testable import Automerge
 
 class ProxyCounterTests: XCTestCase {
-    func testAssignmentExpressions() {
+    func testAdditionAssignmentOperator() {
+        struct Schema: Codable, Equatable {
+            var counter: Counter = 1
+        }
+        
+        var doc1 = Document(Schema())
+        let _ = doc1.change {
+            $0.counter += 1
+            XCTAssertEqual($0.counter.get(), 2)
+        }
+        
+        XCTAssertEqual(doc1.content, Schema(counter: 2))
+    }
+    
+    func testAdditionAssignmentOperatorOnOptional() {
         struct Schema: Codable, Equatable {
             var counter: Counter?
-            var notOptionalCounter: Counter = 3
         }
         
         var doc1 = Document(Schema())
@@ -23,26 +36,43 @@ class ProxyCounterTests: XCTestCase {
         }
         
         let _ = doc1.change {
-            $0.counter -= 1
-            $0.notOptionalCounter -= 1
-            XCTAssertEqual($0.counter?.get(), 2)
-            XCTAssertEqual($0.notOptionalCounter.get(), 2)
-        }
-        
-        let _ = doc1.change {
             $0.counter += 2
-            $0.notOptionalCounter += 2
-            XCTAssertEqual($0.counter?.get(), 4)
-            XCTAssertEqual($0.notOptionalCounter.get(), 4)
+            XCTAssertEqual($0.counter?.get(), 5)
+        }
+        
+        XCTAssertEqual(doc1.content, Schema(counter: 5))
+    }
+    
+    func testSubstractionAssignmentOperator() {
+        struct Schema: Codable, Equatable {
+            var counter: Counter = 1
+        }
+        
+        var doc1 = Document(Schema())
+        let _ = doc1.change {
+            $0.counter -= 1
+            XCTAssertEqual($0.counter.get(), 0)
+        }
+        
+        XCTAssertEqual(doc1.content, Schema(counter: 0))
+    }
+    
+    func testSubstractionAssignmentOperatorOnOptional() {
+        struct Schema: Codable, Equatable {
+            var counter: Counter?
+        }
+        
+        var doc1 = Document(Schema())
+        let _ = doc1.change {
+            $0.counter?.set(3)
+            XCTAssertEqual($0.counter?.get(), 3)
         }
         
         let _ = doc1.change {
-            $0.counter += -2
-            $0.notOptionalCounter -= 2
-            XCTAssertEqual($0.counter?.get(), 2)
-            XCTAssertEqual($0.notOptionalCounter.get(), 2)
+            $0.counter -= 2
+            XCTAssertEqual($0.counter?.get(), 1)
         }
         
-        XCTAssertEqual(doc1.content, Schema(counter: 2, notOptionalCounter: 2))
+        XCTAssertEqual(doc1.content, Schema(counter: 1))
     }
 }


### PR DESCRIPTION
As proposed in #4, Extends the Counter API to enable increment and decrement of the counter's value using addition assignment and subtraction assignment operators e.g.

```swift
struct Schema: Codable, Equatable {
    var counter: Counter?
}

var doc1 = Document(Schema())
let _ = doc1.change {
    $0.counter?.set(3)
}

let _ = doc1.change {
    $0.counter -= 1
    XCTAssertEqual($0.counter?.get(), 2)
}

let _ = doc1.change {
    $0.counter += 1
    XCTAssertEqual($0.counter?.get(), 3)
}
```