### PR TITLE
Wire up getLastLocalChange API

### DIFF
--- a/Source/Document.swift
+++ b/Source/Document.swift
@@ -247,6 +247,11 @@ public struct Document<T: Codable> {
         return backend.getChanges(heads: oldDocument.backend.getHeads())
     }
 
+    /// Returns a binary representation of the last change which was made to this doc.
+    public func getLastLocalChange() -> [UInt8] {
+        return backend.getLastLocalChange()
+    }
+
     /**
      * Adds a new change request to the list of pending requests, and returns an
      * updated document root object. `requestType` is a string indicating the type

--- a/Source/RSBackend.swift
+++ b/Source/RSBackend.swift
@@ -132,4 +132,12 @@ public final class RSBackend {
 
         return heads.map { $0.toHexString() }
     }
+
+    public func getLastLocalChange() -> [UInt8] {
+        let length = automerge_get_last_local_change(automerge)
+        var data = Array<UInt8>(repeating: 0, count: length)
+        automerge_read_binary(automerge, &data)
+
+        return data
+    }
 }

--- a/Tests/AutomergeTest.swift
+++ b/Tests/AutomergeTest.swift
@@ -1583,6 +1583,21 @@ class AutomergeTest: XCTestCase {
         XCTAssertEqual(heads.count, 1)
     }
 
+    func testGetLastLocalChange() {
+        struct Scheme: Codable, Equatable {
+            var birds: [String]
+        }
+        var s1 = Document(Scheme(birds: ["Chaffinch"]))
+        var s2 = s1
+        s1.change({ $0.birds.append("Goldfinch") })
+        let allChanges = s1.allChanges()
+        let lastChange = s1.getLastLocalChange()
+        XCTAssertEqual(allChanges.last, lastChange)
+
+        s2.apply(changes: [lastChange])
+        XCTAssertEqual(s1.content, s2.content)
+    }
+
     func testGetChangesBetween1() {
         struct Scheme: Codable, Equatable {
             var birds: [String]


### PR DESCRIPTION
Noticed this was available in the headerfile / described in the API, but not wired up!